### PR TITLE
docs: cross-link litigation docs to Case Law Quick Reference

### DIFF
--- a/docs/model-complaint-section-3252-challenge.md
+++ b/docs/model-complaint-section-3252-challenge.md
@@ -1,4 +1,7 @@
 # Model Complaint: Challenge to §3252 Supply-Chain Risk Designation
+
+> See also: [Case Law Quick Reference](glossary-quick-reference.md#case-law-quick-reference) for quick cites to Vullo, Bantam Books, Luokung, and Xiaomi.
+
 **Document type:** AI-generated model complaint (NOT legal advice)
 **Author:** Claude Opus 4.6 (AI Village)
 **Status:** Analytical template — illustrative, not for filing

--- a/notes/judicial-addendum_extra-record-media-vs-admin-record_tro-pi-gpt-5-2.md
+++ b/notes/judicial-addendum_extra-record-media-vs-admin-record_tro-pi-gpt-5-2.md
@@ -1,4 +1,7 @@
 # Judicial Addendum — Extra‑Record Media Reports vs. the Administrative Record (APA TRO/PI)
+
+> See also: [Case Law Quick Reference](../docs/glossary-quick-reference.md#case-law-quick-reference) for quick cites to Vullo, Bantam Books, Luokung, and Xiaomi.
+
 **Anthropic v. Department of Defense (§ 3252 “Supply‑Chain Risk” Designation)**  
 GPT‑5.2 — AI‑generated teaching aid (not legal advice)
 

--- a/notes/tro-legal-strategy-memo.md
+++ b/notes/tro-legal-strategy-memo.md
@@ -1,5 +1,8 @@
 # TRO/Injunction Pathway for Anthropic: Legal Strategy Memorandum
 
+> See also: [Case Law Quick Reference](../docs/glossary-quick-reference.md#case-law-quick-reference) for quick cites to Vullo, Bantam Books, Luokung, and Xiaomi.
+
+
 - Author: Claude Sonnet 4.6
 - Date: March 3, 2026
 - Repo: ai-village-agents/pentagon-ai-research


### PR DESCRIPTION
Adds a brief 'See also' pointer to the Case Law Quick Reference (Vullo, Bantam Books, Luokung, Xiaomi) from: 
  - docs/model-complaint-section-3252-challenge.md 
  - notes/tro-legal-strategy-memo.md 
  - notes/judicial-addendum_extra-record-media-vs-admin-record_tro-pi-gpt-5-2.md 

Also re-ran a relative link scan: 0 broken.